### PR TITLE
Feat claim window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "whoami-paths"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whoami-paths"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["callumanderson <callumanderson745@gmail.com>"]
 edition = "2018"
 

--- a/schema/config.json
+++ b/schema/config.json
@@ -4,11 +4,25 @@
   "type": "object",
   "required": [
     "admin",
+    "initial_height",
     "whoami_address"
   ],
   "properties": {
     "admin": {
       "$ref": "#/definitions/Addr"
+    },
+    "initial_height": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "path_root_claim_blocks": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint64",
+      "minimum": 0.0
     },
     "token_id": {
       "type": [

--- a/schema/instantiate_msg.json
+++ b/schema/instantiate_msg.json
@@ -10,6 +10,14 @@
     "admin": {
       "type": "string"
     },
+    "path_root_claim_blocks": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint64",
+      "minimum": 0.0
+    },
     "payment_details": {
       "anyOf": [
         {

--- a/schema/query_msg.json
+++ b/schema/query_msg.json
@@ -37,6 +37,26 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "claim_info"
+      ],
+      "properties": {
+        "claim_info": {
+          "type": "object",
+          "required": [
+            "path"
+          ],
+          "properties": {
+            "path": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,4 +36,7 @@ pub enum ContractError {
 
     #[error("The token address provided is not a valid CW20 token")]
     InvalidCw20 {},
+
+    #[error("For the path exists root token with same name")]
+    RootInClaimWindowToken {},
 }

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -135,6 +135,7 @@ mod tests {
             admin: ADMIN.to_string(),
             whoami_address: whoami_addr.to_string(),
             payment_details,
+            path_root_claim_blocks: None,
         };
         app.instantiate_contract(
             whoami_paths,

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -1180,6 +1180,23 @@ mod tests {
         }
 
         #[test]
+        fn test_mint_path_existing_root_owner_claim_window_passed() {
+            let mut app = mock_app();
+            let (whoami, paths, token_id) = setup_test_case_with_name(&mut app, None, Some(1));
+
+            // Mint the name
+            let root_token_id = "another_root".to_string();
+            mint_name(&mut app, whoami.clone(), USER, &root_token_id).unwrap();
+
+            let path = root_token_id.clone();
+
+            mint_path_native(&mut app, paths, USER2, &path, vec![]).unwrap();
+
+            let resp = get_nft_owner(&mut app, whoami, format!("{}::{}", token_id, path));
+            assert_eq!(resp.owner, USER2.to_string());
+        }
+
+        #[test]
         #[should_panic(expected = "This message does no accept funds")]
         fn test_mint_path_pay_native() {
             let mut app = mock_app();
@@ -1222,6 +1239,30 @@ mod tests {
             let path = root_token_id.clone();
 
             mint_path_cw20(&mut app, cw20_addr, paths, USER, Uint128::new(100), &path).unwrap();
+        }
+
+        #[test]
+        fn test_mint_path_pay_cw20_passed_claim_window() {
+            let mut app = mock_app();
+            let cw20_addr = instantiate_cw20(&mut app);
+            let (whoami, paths, token_id) = setup_test_case_with_name(
+                &mut app,
+                Some(PaymentDetails::Cw20 {
+                    token_address: cw20_addr.to_string(),
+                    amount: Uint128::new(100),
+                }),
+                Some(1),
+            );
+
+            // Mint the name
+            let root_token_id = "another_root".to_string();
+            mint_name(&mut app, whoami.clone(), USER, &root_token_id).unwrap();
+
+            let path = root_token_id.clone();
+
+            mint_path_cw20(&mut app, cw20_addr, paths, USER, Uint128::new(100), &path).unwrap();
+            let resp = get_nft_owner(&mut app, whoami, format!("{}::{}", token_id, path));
+            assert_eq!(resp.owner, USER.to_string());
         }
     }
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -22,6 +22,7 @@ pub struct InstantiateMsg {
     pub admin: String,          // Only the admin can withdraw the name if needed
     pub whoami_address: String, // Address of base whoami contract
     pub payment_details: Option<PaymentDetails>, // Users may have to pay in a cw20 or a native token
+    pub path_root_claim_blocks: Option<u64>, // Allow users with (de)NS root token to claim the path
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -47,6 +48,7 @@ pub enum QueryMsg {
     Config {},
     PaymentDetails {},
     PaymentDetailsBalance {},
+    ClaimInfo { path: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -60,4 +62,11 @@ pub struct PaymentDetailsResponse {
 pub struct PaymentDetailsBalanceResponse {
     pub payment_details: Option<PaymentDetails>,
     pub amount: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct ClaimInfoResponse {
+    pub is_in_claim_window: bool,
+    pub path_as_base_owner: Option<String>,
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -70,3 +70,9 @@ pub struct ClaimInfoResponse {
     pub is_in_claim_window: bool,
     pub path_as_base_owner: Option<String>,
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct MigrateMsg {
+    pub path_root_claim_blocks: Option<u64>,
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,6 +10,8 @@ pub struct Config {
     pub whoami_address: String,
     pub admin: Addr,
     pub token_id: Option<String>, // If we have received a name to mint paths off this will be the token_id
+    pub path_root_claim_blocks: Option<u64>,
+    pub initial_height: u64,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");


### PR DESCRIPTION
This change introduces the ability for the mint-path contract to define a number of blocks as the claim period. During this period, the path is checked to see if it exists as a root (de)NS domain.

If the root does exist and the minter is not the owner of the root domain, execution is forbidden. However, if the minter is the owner of the root domain, minting is free during the claim period. On the other hand, if the path doesn't exist as the root domain, the minting process will proceed as usual.

For example, if the root domain is `username` and another domain `howlpack` exists, and if the whoami-paths contain username NFT and the attribute `path_root_claim_blocks` is defined, then for the amount of blocks nobody can mint username::howlpack except for the owner of the howlpack root domain. The owner can do it for free even though the minting is paid.

After the amount of blocks have passed, then anyone can mint username::howlpack. However, they will have to pay for it as defined in the whoami-path contract, even the owner of the howlpack domain.